### PR TITLE
Support clojure.lang.Symbol

### DIFF
--- a/deps.edn
+++ b/deps.edn
@@ -1,0 +1,4 @@
+{:paths ["src"]
+ :deps  {org.clojure/clojure {:mvn/version "1.8.0"}
+         io.aviso/pretty     {:mvn/version "0.1.30"}
+         rhizome             {:mvn/version "0.2.5"}}}

--- a/src/com/walmartlabs/datascope.clj
+++ b/src/com/walmartlabs/datascope.clj
@@ -2,7 +2,7 @@
   (:require [rhizome.viz :as viz]
             [clojure.string :as str]
             [io.aviso.exception :refer [demangle]])
-  (:import [clojure.lang ISeq IPersistentVector IPersistentMap IDeref IPersistentSet AFn]))
+  (:import [clojure.lang ISeq IPersistentVector IPersistentMap IDeref IPersistentSet AFn Symbol]))
 
 (defn ^:private html-safe
   [s]
@@ -36,6 +36,10 @@
 
   Object
   (as-label [v] (-> v pr-str html-safe))
+
+  Symbol
+  (as-label [v]
+    (str "<i>" (-> v pr-str html-safe) "</i>"))
 
   AFn
   (as-label [f]


### PR DESCRIPTION
Old behaviour:
(as-label 'my-symbol)
=> "<i>clojure.lang.Symbol</i>"

New behaviour:
(as-label 'my-symbol)
=> "<i>my-symbol</i>"